### PR TITLE
fix: add error message attribute

### DIFF
--- a/src/app/admin/campus/campus-list/campus-list.component.html
+++ b/src/app/admin/campus/campus-list/campus-list.component.html
@@ -13,9 +13,9 @@
         [link]="'/admin/campus/' + campus.id">
         <div card-actions></div>
         <div card-actions>
-          <mat-slide-toggle 
-            color="primary" 
-            [checked]="handleEnabled(campus)" 
+          <mat-slide-toggle
+            color="primary"
+            [checked]="handleEnabled(campus)"
             (click)="toggleCampus($event, campus)"></mat-slide-toggle>
         </div>
       </app-card>

--- a/src/app/admin/campus/campus-list/campus-list.component.ts
+++ b/src/app/admin/campus/campus-list/campus-list.component.ts
@@ -3,7 +3,7 @@ import { Campus } from "../../../core/models/campus.model";
 import { CampusService } from "../../../core/services/campus.service";
 import { NotificationService } from "../../../core/services/notification.service";
 import { LoaderService } from "../../../core/services/loader.service";
-import { finalize, first, map } from "rxjs/operators";
+import {finalize, first, map, retry} from "rxjs/operators";
 import { Observable } from "rxjs";
 import { EntityStatus } from 'src/app/core/models/enums/status';
 import { EntityUpdateStatus } from 'src/app/core/models/status.model';
@@ -21,7 +21,7 @@ export class CampusListComponent implements OnInit {
   campuses$: Observable<Campus[]>;
   selectedFilter: number = 1;
   filterNames: string[] = ['Todos', 'Habilitados', 'Desabilitados'];
-  errorMessage: string = "Erro ao carregar os campus";
+  errorMessage: string = "";
   constructor(
     private campusService: CampusService,
     private notificationService: NotificationService,
@@ -33,6 +33,7 @@ export class CampusListComponent implements OnInit {
     this.loaderService.show();
     this.campuses$ = this.campusService.getCampuses()
       .pipe(
+        retry(1),
         finalize(() => {
           this.loaderService.hide();
         })

--- a/src/app/admin/campus/campus-list/campus-list.component.ts
+++ b/src/app/admin/campus/campus-list/campus-list.component.ts
@@ -19,8 +19,9 @@ import { FilterDialogComponent } from 'src/app/core/components/filter-dialog/fil
 })
 export class CampusListComponent implements OnInit {
   campuses$: Observable<Campus[]>;
-  selectedFilter: number = 1; 
+  selectedFilter: number = 1;
   filterNames: string[] = ['Todos', 'Habilitados', 'Desabilitados'];
+  errorMessage: string = "Erro ao carregar os campus";
   constructor(
     private campusService: CampusService,
     private notificationService: NotificationService,
@@ -47,7 +48,7 @@ export class CampusListComponent implements OnInit {
         })
     );
   }
-  
+
   private getDialogConfig() {
     return {
       autoFocus: true,
@@ -62,7 +63,7 @@ export class CampusListComponent implements OnInit {
           }
           if ($event.value == 3) {
             this.selectedFilter = 3;
-          } 
+          }
         },
         handleFilter: () => {
           if (this.selectedFilter == 1) {

--- a/src/app/admin/campus/campus-list/campus-list.component.ts
+++ b/src/app/admin/campus/campus-list/campus-list.component.ts
@@ -3,8 +3,8 @@ import { Campus } from "../../../core/models/campus.model";
 import { CampusService } from "../../../core/services/campus.service";
 import { NotificationService } from "../../../core/services/notification.service";
 import { LoaderService } from "../../../core/services/loader.service";
-import {finalize, first, map, retry} from "rxjs/operators";
-import { Observable } from "rxjs";
+import {catchError, finalize, first, map, retry} from "rxjs/operators";
+import {Observable, of} from "rxjs";
 import { EntityStatus } from 'src/app/core/models/enums/status';
 import { EntityUpdateStatus } from 'src/app/core/models/status.model';
 import { MatDialog } from '@angular/material/dialog';
@@ -34,6 +34,9 @@ export class CampusListComponent implements OnInit {
     this.campuses$ = this.campusService.getCampuses()
       .pipe(
         retry(1),
+        catchError(error => {
+          return of([]);
+        }),
         finalize(() => {
           this.loaderService.hide();
         })

--- a/src/app/admin/campus/campus-list/campus-list.component.ts
+++ b/src/app/admin/campus/campus-list/campus-list.component.ts
@@ -35,6 +35,7 @@ export class CampusListComponent implements OnInit {
       .pipe(
         retry(1),
         catchError(error => {
+          this.notificationService.error("Erro ao carregar os campus");
           return of([]);
         }),
         finalize(() => {


### PR DESCRIPTION
Fixes #109

Neste pull request, foi corrigido o método `ngOnInit` do componente `campus-list`, sendo adicionado o operador `retry` para realizar uma segunda requisição se ocorrer algum erro com a primeira. Caso também ocorra um erro nessa segunda requisição, o operador `catchError` adicionado irá interceptar esse erro, apresentar uma notificação de erro ao usuário e retornar um array vazio.

Para verificar se essas modificações funcionam, basta logar como admin, parar de rodar o back-end e acessar a página que lista os campus. Após a realização desses passos, será apresentada uma notificação de erro. Ademais, para verificar se é feita uma segunda requisição quando ocorre um erro com a primeira, é necessário acessar a aba NetWork do DevTools.

Uma possível melhoria seria utilizar o código desenvolvido nesse pull request em outras partes do projeto que realizam a listagem de algo.