### PR TITLE
refactor: refactor campus list code

### DIFF
--- a/src/app/admin/campus/campus-list/campus-list.component.ts
+++ b/src/app/admin/campus/campus-list/campus-list.component.ts
@@ -3,7 +3,7 @@ import { Campus } from "../../../core/models/campus.model";
 import { CampusService } from "../../../core/services/campus.service";
 import { NotificationService } from "../../../core/services/notification.service";
 import { LoaderService } from "../../../core/services/loader.service";
-import {catchError, finalize, first, map, retry} from "rxjs/operators";
+import {catchError, finalize, first, retry} from "rxjs/operators";
 import {Observable, of} from "rxjs";
 import { EntityStatus } from 'src/app/core/models/enums/status';
 import { EntityUpdateStatus } from 'src/app/core/models/status.model';
@@ -41,7 +41,7 @@ export class CampusListComponent implements OnInit {
         finalize(() => {
           this.loaderService.hide();
         })
-    );
+      );
   }
 
   loadAll(): void {
@@ -51,7 +51,7 @@ export class CampusListComponent implements OnInit {
         finalize(() => {
           this.loaderService.hide();
         })
-    );
+      );
   }
 
   private getDialogConfig() {
@@ -74,9 +74,8 @@ export class CampusListComponent implements OnInit {
           }
           if (this.selectedFilter == 2 ) {
             this.loaderService.show();
-            this.campuses$ = this.campusService.getCampuses()
+            this.campuses$ = this.campusService.getAllCampusByStatus(EntityStatus.ENABLED)
               .pipe(
-                map(campus => campus.filter(c => c.status === EntityStatus.ENABLED)),
                 finalize(() => {
                   this.loaderService.hide();
                 })
@@ -84,9 +83,8 @@ export class CampusListComponent implements OnInit {
           }
           if (this.selectedFilter == 3) {
             this.loaderService.show();
-            this.campuses$ = this.campusService.getCampuses()
+            this.campuses$ = this.campusService.getAllCampusByStatus(EntityStatus.DISABLED)
               .pipe(
-                map(campus => campus.filter(c => c.status === EntityStatus.DISABLED)),
                 finalize(() => {
                   this.loaderService.hide();
                 })
@@ -101,7 +99,7 @@ export class CampusListComponent implements OnInit {
 
   openDialog() {
     this.dialog.open(FilterDialogComponent, this.getDialogConfig())
-    .afterClosed()
+      .afterClosed()
   }
 
   handleEnabled(campus: Campus): boolean {

--- a/src/app/admin/campus/campus-list/campus-list.component.ts
+++ b/src/app/admin/campus/campus-list/campus-list.component.ts
@@ -63,7 +63,7 @@ export class CampusListComponent implements OnInit {
           }
           if (this.selectedFilter == 2 ) {
             this.loaderService.show();
-            this.campuses$ = this.campusService.getAllCampusByStatus(EntityStatus.ENABLED)
+            this.campuses$ = this.campusService.getAllCampusesByStatus(EntityStatus.ENABLED)
               .pipe(
                 finalize(() => {
                   this.loaderService.hide();
@@ -72,7 +72,7 @@ export class CampusListComponent implements OnInit {
           }
           if (this.selectedFilter == 3) {
             this.loaderService.show();
-            this.campuses$ = this.campusService.getAllCampusByStatus(EntityStatus.DISABLED)
+            this.campuses$ = this.campusService.getAllCampusesByStatus(EntityStatus.DISABLED)
               .pipe(
                 finalize(() => {
                   this.loaderService.hide();

--- a/src/app/admin/campus/campus-list/campus-list.component.ts
+++ b/src/app/admin/campus/campus-list/campus-list.component.ts
@@ -60,15 +60,7 @@ export class CampusListComponent implements OnInit {
       data: {
         filterNames: this.filterNames,
         onChange: ($event: MatRadioChange) => {
-          if ($event.value == 1) {
-            this.selectedFilter = 1;
-          }
-          if ($event.value == 2) {
-            this.selectedFilter = 2;
-          }
-          if ($event.value == 3) {
-            this.selectedFilter = 3;
-          }
+          this.selectedFilter = $event.value;
         },
         handleFilter: () => {
           if (this.selectedFilter == 1) {

--- a/src/app/admin/campus/campus-list/campus-list.component.ts
+++ b/src/app/admin/campus/campus-list/campus-list.component.ts
@@ -21,7 +21,6 @@ export class CampusListComponent implements OnInit {
   campuses$: Observable<Campus[]>;
   selectedFilter: number = 1;
   filterNames: string[] = ['Todos', 'Habilitados', 'Desabilitados'];
-  errorMessage: string = "";
   constructor(
     private campusService: CampusService,
     private notificationService: NotificationService,
@@ -34,20 +33,10 @@ export class CampusListComponent implements OnInit {
     this.campuses$ = this.campusService.getCampuses()
       .pipe(
         retry(1),
-        catchError(error => {
+        catchError(() => {
           this.notificationService.error("Erro ao carregar os campus");
           return of([]);
         }),
-        finalize(() => {
-          this.loaderService.hide();
-        })
-      );
-  }
-
-  loadAll(): void {
-    this.loaderService.show();
-    this.campuses$ = this.campusService.getCampuses()
-      .pipe(
         finalize(() => {
           this.loaderService.hide();
         })
@@ -103,7 +92,7 @@ export class CampusListComponent implements OnInit {
   }
 
   handleEnabled(campus: Campus): boolean {
-    return campus.status == EntityStatus.ENABLED ? true : false;
+    return campus.status == EntityStatus.ENABLED;
   }
 
   toggleCampus($event: Event, campus: Campus) {

--- a/src/app/core/services/campus.service.ts
+++ b/src/app/core/services/campus.service.ts
@@ -5,6 +5,7 @@ import { Observable } from "rxjs";
 import { environment } from "../../../environments/environment";
 import { EntityUpdateStatus } from '../models/status.model';
 import { map } from "rxjs/operators";
+import { EntityStatus } from '../models/enums/status';
 
 @Injectable({
   providedIn: 'root'
@@ -32,6 +33,12 @@ export class CampusService {
 
   getCampusById(id: String): Observable<Campus> {
     return this.httpClient.get<Campus>(`${this.apiUrl}/${id}`, this.httpOptions);
+  }
+
+  getAllCampusByStatus(status: EntityStatus): Observable<Campus[]> {
+    return this.httpClient.get<Campus[]>(`${this.apiUrl}?status=${status}`, this.httpOptions).pipe(
+      map(results => results.sort((a, b) => a.name.localeCompare(b.name)))
+    );
   }
 
   updateCampus(id: String, campus: CampusCreate): Observable<Campus> {

--- a/src/app/core/services/campus.service.ts
+++ b/src/app/core/services/campus.service.ts
@@ -35,7 +35,7 @@ export class CampusService {
     return this.httpClient.get<Campus>(`${this.apiUrl}/${id}`, this.httpOptions);
   }
 
-  getAllCampusByStatus(status: EntityStatus): Observable<Campus[]> {
+  getAllCampusesByStatus(status: EntityStatus): Observable<Campus[]> {
     return this.httpClient.get<Campus[]>(`${this.apiUrl}?status=${status}`, this.httpOptions).pipe(
       map(results => results.sort((a, b) => a.name.localeCompare(b.name)))
     );


### PR DESCRIPTION
Resolves issue #110

Neste pull request, foi feito uma refatoração do componente `campus-list`, o que implicou na remoção de código não utilizado,  simplificação de determinadas partes do mesmo e criação do método `getAllCampusesByStatus`. Tal método realiza uma requisição get e recebe os campus já filtrados pela API, o que difere de como o código se comportava, pois era feita a filtragem dos campus no próprio front-end, o que acabava sendo uma opção ruim, pois deixava todos os campus em memória.

Para verificar se essas modificação funcionam, basta logar como admin, acessar a página que lista os campus e selecionar uma opção de filtragem dessa lista.

Uma possível melhoria seria desabilitar o filtro quando não houver campus cadastrados, o que não ocorre atualmente.