### PR TITLE
feat: adds method get curriculums by status in curriculum service

### DIFF
--- a/src/app/admin/course/course-show/course-show.component.ts
+++ b/src/app/admin/course/course-show/course-show.component.ts
@@ -1,21 +1,21 @@
-import { Component, OnInit } from '@angular/core';
-import { Course } from "../../../core/models/course.model";
-import { CourseService } from 'src/app/core/services/course.service';
-import { ActivatedRoute, Router } from "@angular/router";
-import { finalize, first, map } from "rxjs/operators";
-import { NotificationService } from "../../../core/services/notification.service";
-import { ConfirmDialogService } from "../../../core/services/confirm-dialog.service";
-import { MatDialog } from "@angular/material/dialog";
-import { ProblemDetail } from "../../../core/interfaces/problem-detail.interface";
-import { ListItens } from "../../../core/components/content/content-detail/content-detail.component";
-import { LoaderService } from "../../../core/services/loader.service";
-import { Department } from 'src/app/core/models/department.model';
-import { Campus } from 'src/app/core/models/campus.model';
-import { CurriculumService } from 'src/app/core/services/curriculum.service';
-import { Curriculum } from 'src/app/core/models/curriculum.model';
-import { CurriculumCreateComponent } from '../curriculum-create/curriculum-create.component';
-import { EntityStatus } from 'src/app/core/models/enums/status';
-import { EntityUpdateStatus } from 'src/app/core/models/status.model';
+import {Component, OnInit} from '@angular/core';
+import {Course} from "../../../core/models/course.model";
+import {CourseService} from 'src/app/core/services/course.service';
+import {ActivatedRoute, Router} from "@angular/router";
+import {finalize, first} from "rxjs/operators";
+import {NotificationService} from "../../../core/services/notification.service";
+import {ConfirmDialogService} from "../../../core/services/confirm-dialog.service";
+import {MatDialog} from "@angular/material/dialog";
+import {ProblemDetail} from "../../../core/interfaces/problem-detail.interface";
+import {ListItens} from "../../../core/components/content/content-detail/content-detail.component";
+import {LoaderService} from "../../../core/services/loader.service";
+import {Department} from 'src/app/core/models/department.model';
+import {Campus} from 'src/app/core/models/campus.model';
+import {CurriculumService} from 'src/app/core/services/curriculum.service';
+import {Curriculum} from 'src/app/core/models/curriculum.model';
+import {CurriculumCreateComponent} from '../curriculum-create/curriculum-create.component';
+import {EntityStatus} from 'src/app/core/models/enums/status';
+import {EntityUpdateStatus} from 'src/app/core/models/status.model';
 
 @Component({
   selector: 'app-course-show',
@@ -50,38 +50,48 @@ export class CourseShowComponent implements OnInit {
   }
 
   handlerFilterSelected(selected: number) {
+    this.loaderService.show();
     if (selected == 1) {
       this.curriculumService.getCurriculums(this.course.id)
-      .pipe(first())
+      .pipe(
+        first(),
+        finalize(() => {
+          this.loaderService.hide();
+        })
+      )
       .subscribe(
         curriculums => {
           this.curriculums = curriculums
-        },
-      )
+        }
+      );
     }
     if (selected == 2) {
-      this.curriculumService.getCurriculums(this.course.id)
-      .pipe(
-        first(),
-        map(curriculum => curriculum.filter(c => c.status === EntityStatus.ENABLED)),
-      )
-      .subscribe(
-        curriculums => {
-          this.curriculums = curriculums
-        },
-      )
+      this.curriculumService.getCurriculumsByStatus(this.course.id, EntityStatus.ENABLED)
+        .pipe(
+          first(),
+          finalize(() => {
+            this.loaderService.hide();
+          })
+        )
+        .subscribe(
+          curriculums => {
+            this.curriculums = curriculums
+          }
+        );
     }
     if (selected == 3) {
-      this.curriculumService.getCurriculums(this.course.id)
-      .pipe(
-        first(),
-        map(curriculum => curriculum.filter(c => c.status === EntityStatus.DISABLED)),
-      )
-      .subscribe(
-        curriculums => {
-          this.curriculums = curriculums
-        },
-      )
+      this.curriculumService.getCurriculumsByStatus(this.course.id, EntityStatus.DISABLED)
+        .pipe(
+          first(),
+          finalize(() => {
+            this.loaderService.hide();
+          })
+        )
+        .subscribe(
+          curriculums => {
+            this.curriculums = curriculums
+          }
+        );
     }
   }
 

--- a/src/app/core/services/curriculum.service.ts
+++ b/src/app/core/services/curriculum.service.ts
@@ -35,7 +35,7 @@ export class CurriculumService {
   }
 
   getCurriculumsByStatus(courseId: string, status: EntityStatus): Observable<Curriculum[]>{
-    const url = `${this.apiUrl}/${courseId}/curriculums?=${status}`;
+    const url = `${this.apiUrl}/${courseId}/curriculums?status=${status}`;
     return this.httpClient.get<Curriculum[]>(url, this.httpOptions).pipe(
       map(results => results.sort((a, b) => a.code.localeCompare(b.code)))
     );

--- a/src/app/core/services/curriculum.service.ts
+++ b/src/app/core/services/curriculum.service.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs';
 import { Curriculum, CurriculumCreate } from '../models/curriculum.model';
 import { EntityUpdateStatus } from '../models/status.model';
 import { map } from "rxjs/operators";
+import {EntityStatus} from "../models/enums/status";
 
 @Injectable({
   providedIn: 'root'
@@ -28,6 +29,13 @@ export class CurriculumService {
 
   getCurriculums(courseId: string): Observable<Curriculum[]> {
     const url = `${this.apiUrl}/${courseId}/curriculums`;
+    return this.httpClient.get<Curriculum[]>(url, this.httpOptions).pipe(
+      map(results => results.sort((a, b) => a.code.localeCompare(b.code)))
+    );
+  }
+
+  getCurriculumsByStatus(courseId: string, status: EntityStatus): Observable<Curriculum[]>{
+    const url = `${this.apiUrl}/${courseId}/curriculums?=${status}`;
     return this.httpClient.get<Curriculum[]>(url, this.httpOptions).pipe(
       map(results => results.sort((a, b) => a.code.localeCompare(b.code)))
     );


### PR DESCRIPTION
Resolve a Issue #130

Neste Pull Request, para a resolução da Issue #130, foram refatorados o serviço `curriculum-service`, localizado em `core/services`, e o componente `course-show.component` localizado em `admin/course/course-show`.

Em `curriculum-service` foi adicionado o método `getCurriculumByStatus` que recebe como parâmetro um string `courseId` e um `status` com tipo do enum `EntityStatus` (localizado em `core/models/enum`). Esses parâmetros são usados na constante `url` para a construção da chamada ao método `get` do `HttpClient`.

Finalmente, em `course-show.component` foi refatorado o método `handlerFilterSelected`. Foi adicionado o método `show()` do serviço `loaderService`, não presente anteriormente, que tem ação encerrada pelo método `hide()` do mesmo serviço, chamado pelo parâmetro pipe durante as chamadas de métodos do `curriculumService`. Na seleção do primeiro filtro ("Todos", com parâmetro `selected` equivalente a "1") é chamado o método `getCurriculums`, já presente anteriormente, e caso seja selecionado o segundo ou terceiro filtro ("Habilitados" ou "Desabilitados") é chamado o método `getCurriculumsByStatus` do serviço `curriculum.service` que usa como parâmetro o atributo `EntityStatus` para fazer a distinção entre os dois filtros `ENABLED` e `DISABLED`.

Referências:
- Issue #130 https://github.com/ifspcodelab/gestao-estagios-backend/issues/130